### PR TITLE
Feature/persist connections

### DIFF
--- a/dynamiq-ruby-client.gemspec
+++ b/dynamiq-ruby-client.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "rspec"
+  spec.add_runtime_dependency "net-http-persistent"
   
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/spec/dynamiq/client_spec.rb
+++ b/spec/dynamiq/client_spec.rb
@@ -272,7 +272,7 @@ describe Dynamiq::Client do
     end
 
     it "should DELETE messages from queue" do
-      conn.should_receive(:delete).with("queues/q/message/id1,id2,id3")
+      conn.should_receive(:delete).with("queues/q/messages/id1,id2,id3")
       subject.acknowledge_many('q', ['id1','id2','id3'])
     end
   end


### PR DESCRIPTION
ping @theo-lanman @alvindu 

In continuing to look into the networking issues, we're definitely seeing a load of connections being opened from TJS boxes, where we should be able to use a persistent connection.

This gives us the option (defaults to true) to use this connection.

Willing to default it to false, if people feel thats a thing we should do
